### PR TITLE
Update golangci-lint to version v1.42.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        golangci/golangci-lint:v1.35.2
+FROM        golangci/golangci-lint:v1.42.1
 
 ENV         LINT_NAME="mittwald-golangci" \
             LINT_ID="1000" \


### PR DESCRIPTION
The old version uses go 1.15 and the io/fs package does not compile with
this version so use a newer release which uses go 1.17